### PR TITLE
[iOS] "필수 항목입니다." 가 보이지 않는 버그를 수정하고 중복 확인 버튼을 추가하였습니다.

### DIFF
--- a/iOS/SignupApp/SignupApp.xcodeproj/project.pbxproj
+++ b/iOS/SignupApp/SignupApp.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		5A4CA5ED242B7F920095FA0C /* PasswordValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5EC242B7F920095FA0C /* PasswordValidator.swift */; };
 		5A4CA5EF242B7FAA0095FA0C /* RePasswordValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5EE242B7FAA0095FA0C /* RePasswordValidator.swift */; };
 		5A4CA5F1242B7FBF0095FA0C /* NameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5F0242B7FBF0095FA0C /* NameValidator.swift */; };
+		5A6716D8249346280075B510 /* OverlapValidationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6716D7249346280075B510 /* OverlapValidationButton.swift */; };
+		5A6716DA24934D260075B510 /* IDField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6716D924934D260075B510 /* IDField.swift */; };
 		5A7C6306242CB2D70073CF72 /* MessageLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C6305242CB2D70073CF72 /* MessageLabel.swift */; };
 		5A7C630B242CC3270073CF72 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C630A242CC3270073CF72 /* UIColor.swift */; };
 		5A7C6310242D9EEB0073CF72 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C630F242D9EEB0073CF72 /* NetworkManager.swift */; };
@@ -60,6 +62,8 @@
 		5A4CA5EC242B7F920095FA0C /* PasswordValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidator.swift; sourceTree = "<group>"; };
 		5A4CA5EE242B7FAA0095FA0C /* RePasswordValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RePasswordValidator.swift; sourceTree = "<group>"; };
 		5A4CA5F0242B7FBF0095FA0C /* NameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameValidator.swift; sourceTree = "<group>"; };
+		5A6716D7249346280075B510 /* OverlapValidationButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlapValidationButton.swift; sourceTree = "<group>"; };
+		5A6716D924934D260075B510 /* IDField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDField.swift; sourceTree = "<group>"; };
 		5A7C6305242CB2D70073CF72 /* MessageLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageLabel.swift; sourceTree = "<group>"; };
 		5A7C630A242CC3270073CF72 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		5A7C630F242D9EEB0073CF72 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
@@ -115,6 +119,7 @@
 		5A4CA5D7242B4BE60095FA0C /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				5A6716D7249346280075B510 /* OverlapValidationButton.swift */,
 				5A7C6316242DCBAA0073CF72 /* CompleteButton.swift */,
 				5A7C6305242CB2D70073CF72 /* MessageLabel.swift */,
 				5A4CA5E0242B53C90095FA0C /* TextFields */,
@@ -234,6 +239,7 @@
 			children = (
 				5A4CA5E3242B5BB20095FA0C /* SignupField.swift */,
 				5A4CA5DC242B4DAE0095FA0C /* RePasswordField.swift */,
+				5A6716D924934D260075B510 /* IDField.swift */,
 			);
 			path = SignupTextFields;
 			sourceTree = "<group>";
@@ -371,6 +377,7 @@
 			files = (
 				5A7C6312242D9F1B0073CF72 /* DataCoder.swift in Sources */,
 				5A4CA5EB242B7EE30095FA0C /* IDValidator.swift in Sources */,
+				5A6716D8249346280075B510 /* OverlapValidationButton.swift in Sources */,
 				5A834510242A301B00F20FAA /* SignupViewController.swift in Sources */,
 				5A83450C242A301B00F20FAA /* AppDelegate.swift in Sources */,
 				5A7C630B242CC3270073CF72 /* UIColor.swift in Sources */,
@@ -383,6 +390,7 @@
 				5A83450E242A301B00F20FAA /* SceneDelegate.swift in Sources */,
 				5A4CA5ED242B7F920095FA0C /* PasswordValidator.swift in Sources */,
 				5A4CA5E9242B7E9D0095FA0C /* SignupValidator.swift in Sources */,
+				5A6716DA24934D260075B510 /* IDField.swift in Sources */,
 				5A834FB1242F5FC5006245F2 /* FormField.swift in Sources */,
 				5A4CA5F1242B7FBF0095FA0C /* NameValidator.swift in Sources */,
 				5A4CA5DD242B4DAE0095FA0C /* RePasswordField.swift in Sources */,

--- a/iOS/SignupApp/SignupApp.xcodeproj/project.pbxproj
+++ b/iOS/SignupApp/SignupApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5A35D407249799CD0038AD6F /* SignupTextableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A35D406249799CD0038AD6F /* SignupTextableView.swift */; };
 		5A4CA5DD242B4DAE0095FA0C /* RePasswordField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5DC242B4DAE0095FA0C /* RePasswordField.swift */; };
 		5A4CA5E4242B5BB20095FA0C /* SignupField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5E3242B5BB20095FA0C /* SignupField.swift */; };
 		5A4CA5E9242B7E9D0095FA0C /* SignupValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5E8242B7E9D0095FA0C /* SignupValidator.swift */; };
@@ -57,6 +58,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5A35D406249799CD0038AD6F /* SignupTextableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupTextableView.swift; sourceTree = "<group>"; };
 		5A4CA5DC242B4DAE0095FA0C /* RePasswordField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RePasswordField.swift; sourceTree = "<group>"; };
 		5A4CA5E3242B5BB20095FA0C /* SignupField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupField.swift; sourceTree = "<group>"; };
 		5A4CA5E8242B7E9D0095FA0C /* SignupValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupValidator.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				5A7C6316242DCBAA0073CF72 /* CompleteButton.swift */,
 				5A7C6305242CB2D70073CF72 /* MessageLabel.swift */,
 				5A4CA5E0242B53C90095FA0C /* TextFields */,
+				5A35D406249799CD0038AD6F /* SignupTextableView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -402,6 +405,7 @@
 				5A834FB1242F5FC5006245F2 /* FormField.swift in Sources */,
 				5A4CA5F1242B7FBF0095FA0C /* NameValidator.swift in Sources */,
 				5A4CA5DD242B4DAE0095FA0C /* RePasswordField.swift in Sources */,
+				5A35D407249799CD0038AD6F /* SignupTextableView.swift in Sources */,
 				5A834FB72430490D006245F2 /* Login.swift in Sources */,
 				5A7C6315242DA3070073CF72 /* LoginResponse.swift in Sources */,
 				5A834FB9243077D1006245F2 /* SignupURL.swift in Sources */,

--- a/iOS/SignupApp/SignupApp.xcodeproj/project.pbxproj
+++ b/iOS/SignupApp/SignupApp.xcodeproj/project.pbxproj
@@ -16,11 +16,13 @@
 		5A4CA5F1242B7FBF0095FA0C /* NameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5F0242B7FBF0095FA0C /* NameValidator.swift */; };
 		5A6716D8249346280075B510 /* OverlapValidationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6716D7249346280075B510 /* OverlapValidationButton.swift */; };
 		5A6716DA24934D260075B510 /* IDField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6716D924934D260075B510 /* IDField.swift */; };
+		5A6716DC249351700075B510 /* IDResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6716DB249351700075B510 /* IDResponse.swift */; };
+		5A6716DE249351D70075B510 /* CreateUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6716DD249351D70075B510 /* CreateUserResponse.swift */; };
 		5A7C6306242CB2D70073CF72 /* MessageLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C6305242CB2D70073CF72 /* MessageLabel.swift */; };
 		5A7C630B242CC3270073CF72 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C630A242CC3270073CF72 /* UIColor.swift */; };
 		5A7C6310242D9EEB0073CF72 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C630F242D9EEB0073CF72 /* NetworkManager.swift */; };
 		5A7C6312242D9F1B0073CF72 /* DataCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C6311242D9F1B0073CF72 /* DataCoder.swift */; };
-		5A7C6315242DA3070073CF72 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C6314242DA3070073CF72 /* Response.swift */; };
+		5A7C6315242DA3070073CF72 /* LoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C6314242DA3070073CF72 /* LoginResponse.swift */; };
 		5A7C6317242DCBAA0073CF72 /* CompleteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C6316242DCBAA0073CF72 /* CompleteButton.swift */; };
 		5A7C6319242DE2C00073CF72 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7C6318242DE2C00073CF72 /* LoginViewController.swift */; };
 		5A83450C242A301B00F20FAA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A83450B242A301B00F20FAA /* AppDelegate.swift */; };
@@ -64,11 +66,13 @@
 		5A4CA5F0242B7FBF0095FA0C /* NameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameValidator.swift; sourceTree = "<group>"; };
 		5A6716D7249346280075B510 /* OverlapValidationButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlapValidationButton.swift; sourceTree = "<group>"; };
 		5A6716D924934D260075B510 /* IDField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDField.swift; sourceTree = "<group>"; };
+		5A6716DB249351700075B510 /* IDResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDResponse.swift; sourceTree = "<group>"; };
+		5A6716DD249351D70075B510 /* CreateUserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateUserResponse.swift; sourceTree = "<group>"; };
 		5A7C6305242CB2D70073CF72 /* MessageLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageLabel.swift; sourceTree = "<group>"; };
 		5A7C630A242CC3270073CF72 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		5A7C630F242D9EEB0073CF72 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		5A7C6311242D9F1B0073CF72 /* DataCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCoder.swift; sourceTree = "<group>"; };
-		5A7C6314242DA3070073CF72 /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		5A7C6314242DA3070073CF72 /* LoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponse.swift; sourceTree = "<group>"; };
 		5A7C6316242DCBAA0073CF72 /* CompleteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteButton.swift; sourceTree = "<group>"; };
 		5A7C6318242DE2C00073CF72 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		5A834508242A301B00F20FAA /* SignupApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SignupApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -169,9 +173,11 @@
 		5A7C6313242DA2D50073CF72 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				5A7C6314242DA3070073CF72 /* Response.swift */,
 				5A834FB42430459A006245F2 /* User.swift */,
 				5A834FB62430490D006245F2 /* Login.swift */,
+				5A6716DB249351700075B510 /* IDResponse.swift */,
+				5A6716DD249351D70075B510 /* CreateUserResponse.swift */,
+				5A7C6314242DA3070073CF72 /* LoginResponse.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -382,6 +388,7 @@
 				5A83450C242A301B00F20FAA /* AppDelegate.swift in Sources */,
 				5A7C630B242CC3270073CF72 /* UIColor.swift in Sources */,
 				5A4CA5EF242B7FAA0095FA0C /* RePasswordValidator.swift in Sources */,
+				5A6716DC249351700075B510 /* IDResponse.swift in Sources */,
 				5A4CA5E4242B5BB20095FA0C /* SignupField.swift in Sources */,
 				5A7C6319242DE2C00073CF72 /* LoginViewController.swift in Sources */,
 				5A7C6306242CB2D70073CF72 /* MessageLabel.swift in Sources */,
@@ -389,13 +396,14 @@
 				5A7C6310242D9EEB0073CF72 /* NetworkManager.swift in Sources */,
 				5A83450E242A301B00F20FAA /* SceneDelegate.swift in Sources */,
 				5A4CA5ED242B7F920095FA0C /* PasswordValidator.swift in Sources */,
+				5A6716DE249351D70075B510 /* CreateUserResponse.swift in Sources */,
 				5A4CA5E9242B7E9D0095FA0C /* SignupValidator.swift in Sources */,
 				5A6716DA24934D260075B510 /* IDField.swift in Sources */,
 				5A834FB1242F5FC5006245F2 /* FormField.swift in Sources */,
 				5A4CA5F1242B7FBF0095FA0C /* NameValidator.swift in Sources */,
 				5A4CA5DD242B4DAE0095FA0C /* RePasswordField.swift in Sources */,
 				5A834FB72430490D006245F2 /* Login.swift in Sources */,
-				5A7C6315242DA3070073CF72 /* Response.swift in Sources */,
+				5A7C6315242DA3070073CF72 /* LoginResponse.swift in Sources */,
 				5A834FB9243077D1006245F2 /* SignupURL.swift in Sources */,
 				5A834FB52430459A006245F2 /* User.swift in Sources */,
 			);

--- a/iOS/SignupApp/SignupApp.xcodeproj/project.pbxproj
+++ b/iOS/SignupApp/SignupApp.xcodeproj/project.pbxproj
@@ -8,7 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		5A35D407249799CD0038AD6F /* SignupTextableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A35D406249799CD0038AD6F /* SignupTextableView.swift */; };
-		5A35D40924979E990038AD6F /* IDTextableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A35D40824979E990038AD6F /* IDTextableView.swift */; };
+		5A35D40924979E990038AD6F /* IDableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A35D40824979E990038AD6F /* IDableView.swift */; };
+		5A35D40B2497A18D0038AD6F /* RePasswordableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A35D40A2497A18D0038AD6F /* RePasswordableView.swift */; };
 		5A4CA5DD242B4DAE0095FA0C /* RePasswordField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5DC242B4DAE0095FA0C /* RePasswordField.swift */; };
 		5A4CA5E4242B5BB20095FA0C /* SignupField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5E3242B5BB20095FA0C /* SignupField.swift */; };
 		5A4CA5E9242B7E9D0095FA0C /* SignupValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5E8242B7E9D0095FA0C /* SignupValidator.swift */; };
@@ -60,7 +61,8 @@
 
 /* Begin PBXFileReference section */
 		5A35D406249799CD0038AD6F /* SignupTextableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupTextableView.swift; sourceTree = "<group>"; };
-		5A35D40824979E990038AD6F /* IDTextableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDTextableView.swift; sourceTree = "<group>"; };
+		5A35D40824979E990038AD6F /* IDableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDableView.swift; sourceTree = "<group>"; };
+		5A35D40A2497A18D0038AD6F /* RePasswordableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RePasswordableView.swift; sourceTree = "<group>"; };
 		5A4CA5DC242B4DAE0095FA0C /* RePasswordField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RePasswordField.swift; sourceTree = "<group>"; };
 		5A4CA5E3242B5BB20095FA0C /* SignupField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupField.swift; sourceTree = "<group>"; };
 		5A4CA5E8242B7E9D0095FA0C /* SignupValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupValidator.swift; sourceTree = "<group>"; };
@@ -132,7 +134,8 @@
 				5A7C6305242CB2D70073CF72 /* MessageLabel.swift */,
 				5A4CA5E0242B53C90095FA0C /* TextFields */,
 				5A35D406249799CD0038AD6F /* SignupTextableView.swift */,
-				5A35D40824979E990038AD6F /* IDTextableView.swift */,
+				5A35D40824979E990038AD6F /* IDableView.swift */,
+				5A35D40A2497A18D0038AD6F /* RePasswordableView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -391,7 +394,7 @@
 				5A4CA5EB242B7EE30095FA0C /* IDValidator.swift in Sources */,
 				5A6716D8249346280075B510 /* OverlapValidationButton.swift in Sources */,
 				5A834510242A301B00F20FAA /* SignupViewController.swift in Sources */,
-				5A35D40924979E990038AD6F /* IDTextableView.swift in Sources */,
+				5A35D40924979E990038AD6F /* IDableView.swift in Sources */,
 				5A83450C242A301B00F20FAA /* AppDelegate.swift in Sources */,
 				5A7C630B242CC3270073CF72 /* UIColor.swift in Sources */,
 				5A4CA5EF242B7FAA0095FA0C /* RePasswordValidator.swift in Sources */,
@@ -399,6 +402,7 @@
 				5A4CA5E4242B5BB20095FA0C /* SignupField.swift in Sources */,
 				5A7C6319242DE2C00073CF72 /* LoginViewController.swift in Sources */,
 				5A7C6306242CB2D70073CF72 /* MessageLabel.swift in Sources */,
+				5A35D40B2497A18D0038AD6F /* RePasswordableView.swift in Sources */,
 				5A7C6317242DCBAA0073CF72 /* CompleteButton.swift in Sources */,
 				5A7C6310242D9EEB0073CF72 /* NetworkManager.swift in Sources */,
 				5A83450E242A301B00F20FAA /* SceneDelegate.swift in Sources */,

--- a/iOS/SignupApp/SignupApp.xcodeproj/project.pbxproj
+++ b/iOS/SignupApp/SignupApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5A35D407249799CD0038AD6F /* SignupTextableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A35D406249799CD0038AD6F /* SignupTextableView.swift */; };
+		5A35D40924979E990038AD6F /* IDTextableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A35D40824979E990038AD6F /* IDTextableView.swift */; };
 		5A4CA5DD242B4DAE0095FA0C /* RePasswordField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5DC242B4DAE0095FA0C /* RePasswordField.swift */; };
 		5A4CA5E4242B5BB20095FA0C /* SignupField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5E3242B5BB20095FA0C /* SignupField.swift */; };
 		5A4CA5E9242B7E9D0095FA0C /* SignupValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4CA5E8242B7E9D0095FA0C /* SignupValidator.swift */; };
@@ -59,6 +60,7 @@
 
 /* Begin PBXFileReference section */
 		5A35D406249799CD0038AD6F /* SignupTextableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupTextableView.swift; sourceTree = "<group>"; };
+		5A35D40824979E990038AD6F /* IDTextableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDTextableView.swift; sourceTree = "<group>"; };
 		5A4CA5DC242B4DAE0095FA0C /* RePasswordField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RePasswordField.swift; sourceTree = "<group>"; };
 		5A4CA5E3242B5BB20095FA0C /* SignupField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupField.swift; sourceTree = "<group>"; };
 		5A4CA5E8242B7E9D0095FA0C /* SignupValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupValidator.swift; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 				5A7C6305242CB2D70073CF72 /* MessageLabel.swift */,
 				5A4CA5E0242B53C90095FA0C /* TextFields */,
 				5A35D406249799CD0038AD6F /* SignupTextableView.swift */,
+				5A35D40824979E990038AD6F /* IDTextableView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -388,6 +391,7 @@
 				5A4CA5EB242B7EE30095FA0C /* IDValidator.swift in Sources */,
 				5A6716D8249346280075B510 /* OverlapValidationButton.swift in Sources */,
 				5A834510242A301B00F20FAA /* SignupViewController.swift in Sources */,
+				5A35D40924979E990038AD6F /* IDTextableView.swift in Sources */,
 				5A83450C242A301B00F20FAA /* AppDelegate.swift in Sources */,
 				5A7C630B242CC3270073CF72 /* UIColor.swift in Sources */,
 				5A4CA5EF242B7FAA0095FA0C /* RePasswordValidator.swift in Sources */,

--- a/iOS/SignupApp/SignupApp/Base.lproj/Main.storyboard
+++ b/iOS/SignupApp/SignupApp/Base.lproj/Main.storyboard
@@ -109,9 +109,6 @@
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <textInputTraits key="textInputTraits" returnKeyType="next" secureTextEntry="YES"/>
-                                <connections>
-                                    <outlet property="pwTextField" destination="pSj-hh-w0t" id="YXO-2j-TK5"/>
-                                </connections>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XWk-gP-4Fv" userLabel="Name Label">
                                 <rect key="frame" x="43.333333333333336" y="454.33333333333331" width="26.000000000000007" height="18"/>

--- a/iOS/SignupApp/SignupApp/Base.lproj/Main.storyboard
+++ b/iOS/SignupApp/SignupApp/Base.lproj/Main.storyboard
@@ -40,7 +40,26 @@
                                 </attributedString>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="영문 소문자, 숫자, 특수기호(_,-), 5~20자" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2G8-au-aDX" userLabel="ID Text Field" customClass="SignupField" customModule="SignupApp" customModuleProvider="target">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hPV-kH-5pK" userLabel="Validation Button">
+                                <rect key="frame" x="92.333333333333329" y="183" width="37.999999999999986" height="20"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="guR-22-JGd"/>
+                                </constraints>
+                                <state key="normal">
+                                    <attributedString key="attributedTitle">
+                                        <fragment content="중복 확인">
+                                            <attributes>
+                                                <font key="NSFont" size="10" name="NanumGothic"/>
+                                            </attributes>
+                                        </fragment>
+                                    </attributedString>
+                                </state>
+                                <connections>
+                                    <action selector="validatationButtonDidTouch:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YhD-Iy-ZFf"/>
+                                </connections>
+                            </button>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="영문 소문자, 숫자, 특수기호(_,-), 5~20자" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2G8-au-aDX" userLabel="ID Text Field" customClass="IDField" customModule="SignupApp" customModuleProvider="target">
                                 <rect key="frame" x="43.333333333333343" y="207" width="288.33333333333326" height="37"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
@@ -136,12 +155,14 @@
                             <constraint firstItem="czv-n5-9Uf" firstAttribute="top" secondItem="2G8-au-aDX" secondAttribute="bottom" constant="30" id="1CY-aM-efz"/>
                             <constraint firstItem="XWk-gP-4Fv" firstAttribute="top" secondItem="gaU-HE-YkU" secondAttribute="bottom" constant="30" id="3Va-Ag-utu"/>
                             <constraint firstItem="2G8-au-aDX" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="3fG-Pl-a2i"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hPV-kH-5pK" secondAttribute="trailing" symbolic="YES" id="4A0-ze-44p"/>
                             <constraint firstItem="gaU-HE-YkU" firstAttribute="width" secondItem="l9X-kA-2Sd" secondAttribute="width" id="5XR-2R-e4O"/>
                             <constraint firstItem="ymg-D0-lcL" firstAttribute="top" secondItem="pSj-hh-w0t" secondAttribute="bottom" constant="30" id="5mz-rl-zkq"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="width" secondItem="2G8-au-aDX" secondAttribute="width" multiplier="1.3" id="5xr-j0-NV5"/>
                             <constraint firstItem="2G8-au-aDX" firstAttribute="width" secondItem="pSj-hh-w0t" secondAttribute="width" id="8pd-hr-mDi"/>
                             <constraint firstItem="pSj-hh-w0t" firstAttribute="top" secondItem="czv-n5-9Uf" secondAttribute="bottom" constant="5" id="9B4-c7-vZu"/>
                             <constraint firstItem="MMe-yl-ijN" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="AMF-lX-0pG"/>
+                            <constraint firstItem="hPV-kH-5pK" firstAttribute="centerY" secondItem="dyt-DX-jIP" secondAttribute="centerY" id="AbE-1V-5eu"/>
                             <constraint firstItem="cRE-h7-TXu" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="AcR-CM-ZK7"/>
                             <constraint firstItem="XWk-gP-4Fv" firstAttribute="leading" secondItem="l9X-kA-2Sd" secondAttribute="leading" id="Bvh-km-MWo"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="czv-n5-9Uf" secondAttribute="trailing" symbolic="YES" id="EaT-hQ-HXE"/>
@@ -153,6 +174,7 @@
                             <constraint firstItem="2G8-au-aDX" firstAttribute="leading" secondItem="dyt-DX-jIP" secondAttribute="leading" id="SrZ-tV-Yvo"/>
                             <constraint firstItem="l9X-kA-2Sd" firstAttribute="width" secondItem="cRE-h7-TXu" secondAttribute="width" multiplier="3.428" id="Tie-c1-Udv"/>
                             <constraint firstItem="l9X-kA-2Sd" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="U6N-ao-Lrv"/>
+                            <constraint firstItem="hPV-kH-5pK" firstAttribute="leading" secondItem="dyt-DX-jIP" secondAttribute="trailing" constant="10" id="aZg-Uf-MR9"/>
                             <constraint firstItem="gaU-HE-YkU" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="avo-yq-WbC"/>
                             <constraint firstItem="l9X-kA-2Sd" firstAttribute="top" secondItem="XWk-gP-4Fv" secondAttribute="bottom" constant="5" id="cmV-hb-ErP"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ymg-D0-lcL" secondAttribute="trailing" symbolic="YES" id="kL9-Gi-gCZ"/>

--- a/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
@@ -21,16 +21,21 @@ final class IDValidator: SignupValidator {
     private static let messageNotCorrectID = "5~20자의 영문 소문자, 숫자와 특수기호(_)(-)만 사용 가능합니다."
     private static let messageOverlappedID = "이미 사용중인 아이디입니다."
     private static let messageCorrectID = "사용 가능한 아이디입니다."
-    override func validateCurrentText(of textField: UITextField) {
-        guard let signupField = textField as? SignupField else { return }
-        guard isCorrectID(signupField.text)
-            else { signupField.setWrongCase(message: Self.messageNotCorrectID); return }
+    @discardableResult
+    override func validateCurrentText(of textField: UITextField) -> Bool {
+        guard super.validateCurrentText(of: textField) else { return false }
+        
+        guard let signupField = textField as? SignupField else { return false }
+        guard isCorrectID(signupField.text) else {
+            signupField.setWrongCase(message: Self.messageNotCorrectID)
+            return false
+        }
         
         validateOverlappedID(signupField.text) { isOverlapped in
             guard let isOverlapped = isOverlapped else { return }
             self.setCaseBy(isOverlapped, signupField: signupField)
         }
-        super.validateCurrentText(of: textField)
+        return true
     }
     
     private func validateOverlappedID(_ id: String?, resultHandler: @escaping (Bool?) -> ()) {

--- a/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
@@ -22,7 +22,7 @@ final class IDValidator: SignupValidator {
     override func validateText(of signupTextableView: SignupTextableView?) {
         guard let signupTextableView = signupTextableView else { return }
         
-        guard let idTextableView = signupTextableView as? IDTextableView,
+        guard let idTextableView = signupTextableView as? IDableView,
         idTextableView.status != .isCorrect else { return }
         
         if isCorrectID(idTextableView.text) {

--- a/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
@@ -20,8 +20,6 @@ final class IDValidator: SignupValidator {
     
     private static let messageNotCorrectID = "5~20자의 영문 소문자, 숫자와 특수기호(_)(-)만 사용 가능합니다."
     private static let messageRequireValidation = "사용 가능하지만 아이디 중복 검사를 진행하셔야 합니다."
-    static let messageOverlappedID = "이미 사용중인 아이디입니다."
-    static let messageCorrectID = "사용 가능한 아이디입니다."
     @discardableResult
     override func validateCurrentText(of textField: UITextField) -> Bool {
         guard super.validateCurrentText(of: textField) else { return false }

--- a/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
@@ -9,14 +9,21 @@
 import UIKit
 
 final class IDValidator: SignupValidator {
+    private static let correctIDPattern = "^[a-z0-9_\\-]{5,20}$"
+    private func isCorrectID(_ text: String?) -> Bool {
+        guard let text = text else { return false }
+        
+        return text.range(of: Self.correctIDPattern, options: .regularExpression) != nil
+    }
+}
+
+extension IDValidator {
     private static let messageNotCorrectID = "5~20자의 영문 소문자, 숫자와 특수기호(_)(-)만 사용 가능합니다."
     private static let messageRequireValidation = "사용 가능하지만 아이디 중복 검사를 진행하셔야 합니다."
-    @discardableResult
-    override func validateCurrentText(of textField: UITextField) -> Bool {
-        guard super.validateCurrentText(of: textField) else { return false }
-        
+    
+    override func textFieldDidChangeSelection(_ textField: UITextField) {
         guard let idField = textField as? IDField,
-            idField.status != .isCorrect else { return false }
+        idField.status != .isCorrect else { return }
         
         if isCorrectID(idField.text) {
             idField.setWrongCase(message: Self.messageRequireValidation)
@@ -25,13 +32,20 @@ final class IDValidator: SignupValidator {
             idField.setWrongCase(message: Self.messageNotCorrectID)
             idField.status = .isNotCorrect
         }
-        return false
+        super.textFieldDidChangeSelection(textField)
     }
     
-    private static let correctIDPattern = "^[a-z0-9_\\-]{5,20}$"
-    private func isCorrectID(_ text: String?) -> Bool {
-        guard let text = text else { return false }
+    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+        guard let idField = textField as? IDField,
+        idField.status != .isCorrect else { return false }
         
-        return text.range(of: Self.correctIDPattern, options: .regularExpression) != nil
+        if isCorrectID(idField.text) {
+            idField.setWrongCase(message: Self.messageRequireValidation)
+            idField.status = .isCorrectButNotCheckOverlapValidation
+        } else {
+            idField.setWrongCase(message: Self.messageNotCorrectID)
+            idField.status = .isNotCorrect
+        }
+        return super.textFieldShouldEndEditing(textField)
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
@@ -15,14 +15,14 @@ final class IDValidator: SignupValidator {
         
         return text.range(of: Self.correctIDPattern, options: .regularExpression) != nil
     }
-}
-
-extension IDValidator {
+    
     private static let messageNotCorrectID = "5~20자의 영문 소문자, 숫자와 특수기호(_)(-)만 사용 가능합니다."
     private static let messageRequireValidation = "사용 가능하지만 아이디 중복 검사를 진행하셔야 합니다."
     
-    override func textFieldDidChangeSelection(_ textField: UITextField) {
-        guard let idField = textField as? IDField,
+    override func validateText(of signupTextableView: SignupTextableView?) {
+        guard let signupTextableView = signupTextableView else { return }
+        
+        guard let idField = signupTextableView as? IDField,
         idField.status != .isCorrect else { return }
         
         if isCorrectID(idField.text) {
@@ -32,20 +32,7 @@ extension IDValidator {
             idField.setWrongCase(message: Self.messageNotCorrectID)
             idField.status = .isNotCorrect
         }
-        super.textFieldDidChangeSelection(textField)
-    }
-    
-    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        guard let idField = textField as? IDField,
-        idField.status != .isCorrect else { return false }
         
-        if isCorrectID(idField.text) {
-            idField.setWrongCase(message: Self.messageRequireValidation)
-            idField.status = .isCorrectButNotCheckOverlapValidation
-        } else {
-            idField.setWrongCase(message: Self.messageNotCorrectID)
-            idField.status = .isNotCorrect
-        }
-        return super.textFieldShouldEndEditing(textField)
+        super.validateText(of: idField)
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
@@ -22,17 +22,17 @@ final class IDValidator: SignupValidator {
     override func validateText(of signupTextableView: SignupTextableView?) {
         guard let signupTextableView = signupTextableView else { return }
         
-        guard let idField = signupTextableView as? IDField,
-        idField.status != .isCorrect else { return }
+        guard let idTextableView = signupTextableView as? IDTextableView,
+        idTextableView.status != .isCorrect else { return }
         
-        if isCorrectID(idField.text) {
-            idField.setWrongCase(message: Self.messageRequireValidation)
-            idField.status = .isCorrectButNotCheckOverlapValidation
+        if isCorrectID(idTextableView.text) {
+            idTextableView.setWrongCase(message: Self.messageRequireValidation)
+            idTextableView.status = .isCorrectButNotCheckOverlapValidation
         } else {
-            idField.setWrongCase(message: Self.messageNotCorrectID)
-            idField.status = .isNotCorrect
+            idTextableView.setWrongCase(message: Self.messageNotCorrectID)
+            idTextableView.status = .isNotCorrect
         }
         
-        super.validateText(of: idField)
+        super.validateText(of: idTextableView)
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
@@ -9,15 +9,6 @@
 import UIKit
 
 final class IDValidator: SignupValidator {
-    override func textFieldDidChangeSelection(_ textField: UITextField) {
-        validateCurrentText(of: textField)
-    }
-    
-    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        validateCurrentText(of: textField)
-        return true
-    }
-    
     private static let messageNotCorrectID = "5~20자의 영문 소문자, 숫자와 특수기호(_)(-)만 사용 가능합니다."
     private static let messageRequireValidation = "사용 가능하지만 아이디 중복 검사를 진행하셔야 합니다."
     @discardableResult

--- a/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
@@ -9,13 +9,6 @@
 import UIKit
 
 final class IDValidator: SignupValidator {
-    private static let correctIDPattern = "^[a-z0-9_\\-]{5,20}$"
-    private func isCorrectID(_ text: String?) -> Bool {
-        guard let text = text else { return false }
-        
-        return text.range(of: Self.correctIDPattern, options: .regularExpression) != nil
-    }
-    
     private static let messageNotCorrectID = "5~20자의 영문 소문자, 숫자와 특수기호(_)(-)만 사용 가능합니다."
     private static let messageRequireValidation = "사용 가능하지만 아이디 중복 검사를 진행하셔야 합니다."
     
@@ -34,5 +27,13 @@ final class IDValidator: SignupValidator {
         }
         
         super.validateText(of: idTextableView)
+    }
+    
+    private static let correctIDPattern = "^[a-z0-9_\\-]{5,20}$"
+    
+    private func isCorrectID(_ text: String?) -> Bool {
+        guard let text = text else { return false }
+        
+        return text.range(of: Self.correctIDPattern, options: .regularExpression) != nil
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/IDValidator.swift
@@ -24,7 +24,9 @@ final class IDValidator: SignupValidator {
     override func validateCurrentText(of textField: UITextField) -> Bool {
         guard super.validateCurrentText(of: textField) else { return false }
         
-        guard let idField = textField as? IDField else { return false }
+        guard let idField = textField as? IDField,
+            idField.status != .isCorrect else { return false }
+        
         if isCorrectID(idField.text) {
             idField.setWrongCase(message: Self.messageRequireValidation)
             idField.status = .isCorrectButNotCheckOverlapValidation

--- a/iOS/SignupApp/SignupApp/Delegates/NameValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/NameValidator.swift
@@ -9,15 +9,6 @@
 import UIKit
 
 final class NameValidator: SignupValidator {
-    override func textFieldDidChangeSelection(_ textField: UITextField) {
-        validateCurrentText(of: textField)
-    }
-    
-    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        validateCurrentText(of: textField)
-        return true
-    }
-    
     static let messageShouldNotHaveSpace = "공백이 포함되면 안됩니다."
     static let messageCorrectName = "사용가능한 이름입니다."
     @discardableResult

--- a/iOS/SignupApp/SignupApp/Delegates/NameValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/NameValidator.swift
@@ -9,15 +9,6 @@
 import UIKit
 
 final class NameValidator: SignupValidator {
-    private static let spaceCharacterPattern = "[\\s]"
-    private func hasNoSpace(_ text: String?) -> Bool {
-        guard let text = text else { return false }
-        
-        let range = NSRange(location: 0, length: text.count)
-        let regex = try! NSRegularExpression(pattern: Self.spaceCharacterPattern)
-        return regex.firstMatch(in: text, range: range) == nil
-    }
-    
     private static let messageShouldNotHaveSpace = "공백이 포함되면 안됩니다."
     private static let messageCorrectName = "사용가능한 이름입니다."
     
@@ -32,5 +23,13 @@ final class NameValidator: SignupValidator {
         
         super.validateText(of: signupTextableView)
     }
+    
+    private static let spaceCharacterPattern = "[\\s]"
+    private func hasNoSpace(_ text: String?) -> Bool {
+        guard let text = text else { return false }
+        
+        let range = NSRange(location: 0, length: text.count)
+        let regex = try! NSRegularExpression(pattern: Self.spaceCharacterPattern)
+        return regex.firstMatch(in: text, range: range) == nil
+    }
 }
-

--- a/iOS/SignupApp/SignupApp/Delegates/NameValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/NameValidator.swift
@@ -17,33 +17,20 @@ final class NameValidator: SignupValidator {
         let regex = try! NSRegularExpression(pattern: Self.spaceCharacterPattern)
         return regex.firstMatch(in: text, range: range) == nil
     }
+    
+    private static let messageShouldNotHaveSpace = "공백이 포함되면 안됩니다."
+    private static let messageCorrectName = "사용가능한 이름입니다."
+    
+    override func validateText(of signupTextableView: SignupTextableView?) {
+        guard let signupTextableView = signupTextableView else { return }
+        
+        if !hasNoSpace(signupTextableView.text) {
+            signupTextableView.setWrongCase(message: Self.messageShouldNotHaveSpace)
+        } else {
+            signupTextableView.setCorrectCase(message: Self.messageCorrectName)
+        }
+        
+        super.validateText(of: signupTextableView)
+    }
 }
 
-extension NameValidator {
-    static let messageShouldNotHaveSpace = "공백이 포함되면 안됩니다."
-    static let messageCorrectName = "사용가능한 이름입니다."
-    
-    override func textFieldDidChangeSelection(_ textField: UITextField) {
-        guard let nameTextField = textField as? SignupField else { return }
-        
-        if !hasNoSpace(nameTextField.text) {
-            nameTextField.setWrongCase(message: Self.messageShouldNotHaveSpace)
-        } else {
-            nameTextField.setCorrectCase(message: Self.messageCorrectName)
-        }
-    
-        super.textFieldDidChangeSelection(textField)
-    }
-    
-    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        guard let nameTextField = textField as? SignupField else { return false }
-        
-        if !hasNoSpace(nameTextField.text) {
-            nameTextField.setWrongCase(message: Self.messageShouldNotHaveSpace)
-        } else {
-            nameTextField.setCorrectCase(message: Self.messageCorrectName)
-        }
-        
-        return super.textFieldShouldEndEditing(textField)
-    }
-}

--- a/iOS/SignupApp/SignupApp/Delegates/NameValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/NameValidator.swift
@@ -9,22 +9,6 @@
 import UIKit
 
 final class NameValidator: SignupValidator {
-    static let messageShouldNotHaveSpace = "공백이 포함되면 안됩니다."
-    static let messageCorrectName = "사용가능한 이름입니다."
-    @discardableResult
-    override func validateCurrentText(of textField: UITextField) -> Bool {
-        guard super.validateCurrentText(of: textField) else { return false }
-        
-        guard let nameTextField = textField as? SignupField else { return false }
-        guard hasNoSpace(nameTextField.text) else {
-            nameTextField.setWrongCase(message: Self.messageShouldNotHaveSpace)
-            return false 
-        }
-        
-        nameTextField.setCorrectCase(message: Self.messageCorrectName)
-        return true
-    }
-    
     private static let spaceCharacterPattern = "[\\s]"
     private func hasNoSpace(_ text: String?) -> Bool {
         guard let text = text else { return false }
@@ -32,5 +16,34 @@ final class NameValidator: SignupValidator {
         let range = NSRange(location: 0, length: text.count)
         let regex = try! NSRegularExpression(pattern: Self.spaceCharacterPattern)
         return regex.firstMatch(in: text, range: range) == nil
+    }
+}
+
+extension NameValidator {
+    static let messageShouldNotHaveSpace = "공백이 포함되면 안됩니다."
+    static let messageCorrectName = "사용가능한 이름입니다."
+    
+    override func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let nameTextField = textField as? SignupField else { return }
+        
+        if !hasNoSpace(nameTextField.text) {
+            nameTextField.setWrongCase(message: Self.messageShouldNotHaveSpace)
+        } else {
+            nameTextField.setCorrectCase(message: Self.messageCorrectName)
+        }
+    
+        super.textFieldDidChangeSelection(textField)
+    }
+    
+    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+        guard let nameTextField = textField as? SignupField else { return false }
+        
+        if !hasNoSpace(nameTextField.text) {
+            nameTextField.setWrongCase(message: Self.messageShouldNotHaveSpace)
+        } else {
+            nameTextField.setCorrectCase(message: Self.messageCorrectName)
+        }
+        
+        return super.textFieldShouldEndEditing(textField)
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/NameValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/NameValidator.swift
@@ -20,13 +20,18 @@ final class NameValidator: SignupValidator {
     
     static let messageShouldNotHaveSpace = "공백이 포함되면 안됩니다."
     static let messageCorrectName = "사용가능한 이름입니다."
-    override func validateCurrentText(of textField: UITextField) {
-        guard let nameTextField = textField as? SignupField else { return }
-        guard hasNoSpace(nameTextField.text)
-            else { nameTextField.setWrongCase(message: Self.messageShouldNotHaveSpace); return }
+    @discardableResult
+    override func validateCurrentText(of textField: UITextField) -> Bool {
+        guard super.validateCurrentText(of: textField) else { return false }
+        
+        guard let nameTextField = textField as? SignupField else { return false }
+        guard hasNoSpace(nameTextField.text) else {
+            nameTextField.setWrongCase(message: Self.messageShouldNotHaveSpace)
+            return false 
+        }
         
         nameTextField.setCorrectCase(message: Self.messageCorrectName)
-        super.validateCurrentText(of: textField)
+        return true
     }
     
     private static let spaceCharacterPattern = "[\\s]"

--- a/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
@@ -71,3 +71,4 @@ final class PasswordValidator: SignupValidator {
         return regex.firstMatch(in: text, range: range) != nil
     }
 }
+

--- a/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
@@ -12,41 +12,7 @@ final class PasswordValidator: SignupValidator {
     override var textLimit: Int {
         return 16
     }
-    
-    private static let messageCorrectTextLength = "8자 이상 16자 이하로 입력해주세요."
-    private static let messageWriteUpperCapitalLetter = "영문 대문자를 최소 1자 이상 포함해주세요. "
-    private static let messageWriteNumber = "숫자를 최소 1자 이상 포함해주세요."
-    private static let messageWriteSpecialCharacter = "특수문자를 최소 1자 이상 포함해주세요.(!@#$%)"
-    private static let messageCorrectPassword = "안전한 비밀번호입니다."
-    @discardableResult
-    override func validateCurrentText(of textField: UITextField) -> Bool {
-        guard super.validateCurrentText(of: textField) else { return false }
-        
-        guard let pwTextField = textField as? SignupField else { return false }
-        guard isCorrectLength(min: 8, max: 16, count: pwTextField.text?.count) else {
-            pwTextField.setWrongCase(message: Self.messageCorrectTextLength)
-            return false
-        }
-        
-        guard hasUpperCaseLetter(pwTextField.text) else {
-            pwTextField.setWrongCase(message: Self.messageWriteUpperCapitalLetter)
-            return false
-        }
-        
-        guard hasNumber(pwTextField.text) else {
-            pwTextField.setWrongCase(message: Self.messageWriteNumber)
-            return false
-        }
-        
-        guard hasSpecialCharacter(pwTextField.text) else {
-            pwTextField.setWrongCase(message: Self.messageWriteSpecialCharacter)
-            return false
-        }
-        
-        pwTextField.setCorrectCase(message: Self.messageCorrectPassword)
-        return true
-    }
-    
+
     private func isCorrectLength(min: Int = 1, max: Int, count: Int?) -> Bool {
         guard let count = count else { return false }
         
@@ -78,5 +44,50 @@ final class PasswordValidator: SignupValidator {
         let range = NSRange(location: 0, length: text.count)
         let regex = try! NSRegularExpression(pattern: Self.hasSpecialCharacterPattern)
         return regex.firstMatch(in: text, range: range) != nil
+    }
+}
+
+extension PasswordValidator {
+    private static let messageCorrectTextLength = "8자 이상 16자 이하로 입력해주세요."
+    private static let messageWriteUpperCapitalLetter = "영문 대문자를 최소 1자 이상 포함해주세요. "
+    private static let messageWriteNumber = "숫자를 최소 1자 이상 포함해주세요."
+    private static let messageWriteSpecialCharacter = "특수문자를 최소 1자 이상 포함해주세요.(!@#$%)"
+    private static let messageCorrectPassword = "안전한 비밀번호입니다."
+    
+    override func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let pwTextField = textField as? SignupField else { return }
+        
+        if !isCorrectLength(min: 8, max: 16, count: pwTextField.text?.count) {
+            pwTextField.setWrongCase(message: Self.messageCorrectTextLength)
+            
+        } else if !hasUpperCaseLetter(pwTextField.text) {
+            pwTextField.setWrongCase(message: Self.messageWriteUpperCapitalLetter)
+        } else if !hasNumber(pwTextField.text) {
+            pwTextField.setWrongCase(message: Self.messageWriteNumber)
+        } else if !hasSpecialCharacter(pwTextField.text) {
+            pwTextField.setWrongCase(message: Self.messageWriteSpecialCharacter)
+        } else {
+            pwTextField.setCorrectCase(message: Self.messageCorrectPassword)
+        }
+        
+        super.textFieldDidChangeSelection(textField)
+    }
+    
+    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+        guard let pwTextField = textField as? SignupField else { return false }
+        
+        if !isCorrectLength(min: 8, max: 16, count: pwTextField.text?.count) {
+            pwTextField.setWrongCase(message: Self.messageCorrectTextLength)
+        } else if !hasUpperCaseLetter(pwTextField.text) {
+            pwTextField.setWrongCase(message: Self.messageWriteUpperCapitalLetter)
+        } else if !hasNumber(pwTextField.text) {
+            pwTextField.setWrongCase(message: Self.messageWriteNumber)
+        } else if !hasSpecialCharacter(pwTextField.text) {
+            pwTextField.setWrongCase(message: Self.messageWriteSpecialCharacter)
+        } else {
+            pwTextField.setCorrectCase(message: Self.messageCorrectPassword)
+        }
+    
+        return super.textFieldShouldEndEditing(textField)
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
@@ -27,19 +27,33 @@ final class PasswordValidator: SignupValidator {
     private static let messageWriteNumber = "숫자를 최소 1자 이상 포함해주세요."
     private static let messageWriteSpecialCharacter = "특수문자를 최소 1자 이상 포함해주세요.(!@#$%)"
     private static let messageCorrectPassword = "안전한 비밀번호입니다."
-    override func validateCurrentText(of textField: UITextField) {
-        guard let pwTextField = textField as? SignupField else { return }
-        guard isCorrectLength(min: 8, max: 16, count: pwTextField.text?.count)
-            else { pwTextField.setWrongCase(message: Self.messageCorrectTextLength); return }
-        guard hasUpperCaseLetter(pwTextField.text)
-            else { pwTextField.setWrongCase(message: Self.messageWriteUpperCapitalLetter); return }
-        guard hasNumber(pwTextField.text)
-            else { pwTextField.setWrongCase(message: Self.messageWriteNumber); return }
-        guard hasSpecialCharacter(pwTextField.text)
-            else { pwTextField.setWrongCase(message: Self.messageWriteSpecialCharacter); return }
+    @discardableResult
+    override func validateCurrentText(of textField: UITextField) -> Bool {
+        guard super.validateCurrentText(of: textField) else { return false }
+        
+        guard let pwTextField = textField as? SignupField else { return false }
+        guard isCorrectLength(min: 8, max: 16, count: pwTextField.text?.count) else {
+            pwTextField.setWrongCase(message: Self.messageCorrectTextLength)
+            return false
+        }
+        
+        guard hasUpperCaseLetter(pwTextField.text) else {
+            pwTextField.setWrongCase(message: Self.messageWriteUpperCapitalLetter)
+            return false
+        }
+        
+        guard hasNumber(pwTextField.text) else {
+            pwTextField.setWrongCase(message: Self.messageWriteNumber)
+            return false
+        }
+        
+        guard hasSpecialCharacter(pwTextField.text) else {
+            pwTextField.setWrongCase(message: Self.messageWriteSpecialCharacter)
+            return false
+        }
         
         pwTextField.setCorrectCase(message: Self.messageCorrectPassword)
-        super.validateCurrentText(of: textField)
+        return true
     }
     
     private func isCorrectLength(min: Int = 1, max: Int, count: Int?) -> Bool {

--- a/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
@@ -45,49 +45,29 @@ final class PasswordValidator: SignupValidator {
         let regex = try! NSRegularExpression(pattern: Self.hasSpecialCharacterPattern)
         return regex.firstMatch(in: text, range: range) != nil
     }
-}
-
-extension PasswordValidator {
+    
     private static let messageCorrectTextLength = "8자 이상 16자 이하로 입력해주세요."
     private static let messageWriteUpperCapitalLetter = "영문 대문자를 최소 1자 이상 포함해주세요. "
     private static let messageWriteNumber = "숫자를 최소 1자 이상 포함해주세요."
     private static let messageWriteSpecialCharacter = "특수문자를 최소 1자 이상 포함해주세요.(!@#$%)"
     private static let messageCorrectPassword = "안전한 비밀번호입니다."
     
-    override func textFieldDidChangeSelection(_ textField: UITextField) {
-        guard let pwTextField = textField as? SignupField else { return }
+    override func validateText(of signupTextableView: SignupTextableView?) {
+        guard let signupTextableView = signupTextableView else { return }
         
-        if !isCorrectLength(min: 8, max: 16, count: pwTextField.text?.count) {
-            pwTextField.setWrongCase(message: Self.messageCorrectTextLength)
+        if !isCorrectLength(min: 8, max: 16, count: signupTextableView.text?.count) {
+            signupTextableView.setWrongCase(message: Self.messageCorrectTextLength)
             
-        } else if !hasUpperCaseLetter(pwTextField.text) {
-            pwTextField.setWrongCase(message: Self.messageWriteUpperCapitalLetter)
-        } else if !hasNumber(pwTextField.text) {
-            pwTextField.setWrongCase(message: Self.messageWriteNumber)
-        } else if !hasSpecialCharacter(pwTextField.text) {
-            pwTextField.setWrongCase(message: Self.messageWriteSpecialCharacter)
+        } else if !hasUpperCaseLetter(signupTextableView.text) {
+            signupTextableView.setWrongCase(message: Self.messageWriteUpperCapitalLetter)
+        } else if !hasNumber(signupTextableView.text) {
+            signupTextableView.setWrongCase(message: Self.messageWriteNumber)
+        } else if !hasSpecialCharacter(signupTextableView.text) {
+            signupTextableView.setWrongCase(message: Self.messageWriteSpecialCharacter)
         } else {
-            pwTextField.setCorrectCase(message: Self.messageCorrectPassword)
+            signupTextableView.setCorrectCase(message: Self.messageCorrectPassword)
         }
         
-        super.textFieldDidChangeSelection(textField)
-    }
-    
-    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        guard let pwTextField = textField as? SignupField else { return false }
-        
-        if !isCorrectLength(min: 8, max: 16, count: pwTextField.text?.count) {
-            pwTextField.setWrongCase(message: Self.messageCorrectTextLength)
-        } else if !hasUpperCaseLetter(pwTextField.text) {
-            pwTextField.setWrongCase(message: Self.messageWriteUpperCapitalLetter)
-        } else if !hasNumber(pwTextField.text) {
-            pwTextField.setWrongCase(message: Self.messageWriteNumber)
-        } else if !hasSpecialCharacter(pwTextField.text) {
-            pwTextField.setWrongCase(message: Self.messageWriteSpecialCharacter)
-        } else {
-            pwTextField.setCorrectCase(message: Self.messageCorrectPassword)
-        }
-    
-        return super.textFieldShouldEndEditing(textField)
+        super.validateText(of: signupTextableView)
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
@@ -13,15 +13,6 @@ final class PasswordValidator: SignupValidator {
         return 16
     }
     
-    override func textFieldDidChangeSelection(_ textField: UITextField) {
-        validateCurrentText(of: textField)
-    }
-    
-    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        validateCurrentText(of: textField)
-        return true
-    }
-    
     private static let messageCorrectTextLength = "8자 이상 16자 이하로 입력해주세요."
     private static let messageWriteUpperCapitalLetter = "영문 대문자를 최소 1자 이상 포함해주세요. "
     private static let messageWriteNumber = "숫자를 최소 1자 이상 포함해주세요."

--- a/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/PasswordValidator.swift
@@ -12,7 +12,32 @@ final class PasswordValidator: SignupValidator {
     override var textLimit: Int {
         return 16
     }
-
+    
+    private static let messageCorrectTextLength = "8자 이상 16자 이하로 입력해주세요."
+    private static let messageWriteUpperCapitalLetter = "영문 대문자를 최소 1자 이상 포함해주세요. "
+    private static let messageWriteNumber = "숫자를 최소 1자 이상 포함해주세요."
+    private static let messageWriteSpecialCharacter = "특수문자를 최소 1자 이상 포함해주세요.(!@#$%)"
+    private static let messageCorrectPassword = "안전한 비밀번호입니다."
+    
+    override func validateText(of signupTextableView: SignupTextableView?) {
+        guard let signupTextableView = signupTextableView else { return }
+        
+        if !isCorrectLength(min: 8, max: 16, count: signupTextableView.text?.count) {
+            signupTextableView.setWrongCase(message: Self.messageCorrectTextLength)
+            
+        } else if !hasUpperCaseLetter(signupTextableView.text) {
+            signupTextableView.setWrongCase(message: Self.messageWriteUpperCapitalLetter)
+        } else if !hasNumber(signupTextableView.text) {
+            signupTextableView.setWrongCase(message: Self.messageWriteNumber)
+        } else if !hasSpecialCharacter(signupTextableView.text) {
+            signupTextableView.setWrongCase(message: Self.messageWriteSpecialCharacter)
+        } else {
+            signupTextableView.setCorrectCase(message: Self.messageCorrectPassword)
+        }
+        
+        super.validateText(of: signupTextableView)
+    }
+    
     private func isCorrectLength(min: Int = 1, max: Int, count: Int?) -> Bool {
         guard let count = count else { return false }
         
@@ -44,30 +69,5 @@ final class PasswordValidator: SignupValidator {
         let range = NSRange(location: 0, length: text.count)
         let regex = try! NSRegularExpression(pattern: Self.hasSpecialCharacterPattern)
         return regex.firstMatch(in: text, range: range) != nil
-    }
-    
-    private static let messageCorrectTextLength = "8자 이상 16자 이하로 입력해주세요."
-    private static let messageWriteUpperCapitalLetter = "영문 대문자를 최소 1자 이상 포함해주세요. "
-    private static let messageWriteNumber = "숫자를 최소 1자 이상 포함해주세요."
-    private static let messageWriteSpecialCharacter = "특수문자를 최소 1자 이상 포함해주세요.(!@#$%)"
-    private static let messageCorrectPassword = "안전한 비밀번호입니다."
-    
-    override func validateText(of signupTextableView: SignupTextableView?) {
-        guard let signupTextableView = signupTextableView else { return }
-        
-        if !isCorrectLength(min: 8, max: 16, count: signupTextableView.text?.count) {
-            signupTextableView.setWrongCase(message: Self.messageCorrectTextLength)
-            
-        } else if !hasUpperCaseLetter(signupTextableView.text) {
-            signupTextableView.setWrongCase(message: Self.messageWriteUpperCapitalLetter)
-        } else if !hasNumber(signupTextableView.text) {
-            signupTextableView.setWrongCase(message: Self.messageWriteNumber)
-        } else if !hasSpecialCharacter(signupTextableView.text) {
-            signupTextableView.setWrongCase(message: Self.messageWriteSpecialCharacter)
-        } else {
-            signupTextableView.setCorrectCase(message: Self.messageCorrectPassword)
-        }
-        
-        super.validateText(of: signupTextableView)
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
@@ -9,11 +9,6 @@
 import UIKit
 
 final class RePasswordValidator: SignupValidator {
-    private func isSameText(lhs: String?, rhs: String?) -> Bool {
-        guard let lhs = lhs, let rhs = rhs else { return false }
-        return lhs == rhs
-    }
-    
     private static let messagePrePasswordFirst = "이전 비밀번호를 먼저 올바르게 입력해주시기 바랍니다."
     private static let messageNotSamePassword = "비밀번호가 일치하지 않습니다."
     private static let messageSamePassword = "비밀번호가 일치합니다."
@@ -32,5 +27,10 @@ final class RePasswordValidator: SignupValidator {
         }
         
         super.validateText(of: rePasswordableView)
+    }
+    
+    private func isSameText(lhs: String?, rhs: String?) -> Bool {
+        guard let lhs = lhs, let rhs = rhs else { return false }
+        return lhs == rhs
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
@@ -17,20 +17,21 @@ final class RePasswordValidator: SignupValidator {
     private static let messagePrePasswordFirst = "이전 비밀번호를 먼저 올바르게 입력해주시기 바랍니다."
     private static let messageNotSamePassword = "비밀번호가 일치하지 않습니다."
     private static let messageSamePassword = "비밀번호가 일치합니다."
-
+    
     override func validateText(of signupTextableView: SignupTextableView?) {
         guard let signupTextableView = signupTextableView else { return }
+        guard let rePasswordableView = signupTextableView as? RePasswordableView else { return }
         
-        guard let pwAgainTextField = signupTextableView as? RePasswordField else { return }
-        
-        if !pwAgainTextField.pwTextField.isCorrect{
-            pwAgainTextField.setWrongCase(message: Self.messagePrePasswordFirst)
-        } else if !isSameText(lhs: pwAgainTextField.pwTextField.text, rhs: pwAgainTextField.text) {
-            pwAgainTextField.setWrongCase(message: Self.messageNotSamePassword)
+        if !isSameText(lhs: rePasswordableView.passwordTextableView?.text, rhs: rePasswordableView.text) {
+            rePasswordableView.setWrongCase(message: Self.messageNotSamePassword)
         } else {
-            pwAgainTextField.setCorrectCase(message: Self.messageSamePassword)
+            rePasswordableView.setCorrectCase(message: Self.messageSamePassword)
         }
         
-        super.validateText(of: pwAgainTextField)
+        super.validateText(of: rePasswordableView)
     }
 }
+
+//if !pwAgainTextField.passwordTextableView.isCorrect{
+//         pwAgainTextField.setWrongCase(message: Self.messagePrePasswordFirst)
+//}

--- a/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
@@ -9,29 +9,42 @@
 import UIKit
 
 final class RePasswordValidator: SignupValidator {
-    private static let messagePrePasswordFirst = "이전 비밀번호를 먼저 올바르게 입력해주시기 바랍니다."
-    private static let messageNotSamePassword = "비밀번호가 일치하지 않습니다."
-    private static let messageSamePassword = "비밀번호가 일치합니다."
-    @discardableResult
-    override func validateCurrentText(of textField: UITextField) -> Bool {
-        guard super.validateCurrentText(of: textField) else { return false }
-        
-        guard let pwAgainTextField = textField as? RePasswordField else { return false }
-        guard pwAgainTextField.pwTextField.isCorrect else {
-            pwAgainTextField.setWrongCase(message: Self.messagePrePasswordFirst)
-            return false
-        }
-        
-        guard isSameText(lhs: pwAgainTextField.pwTextField.text, rhs: pwAgainTextField.text) else { pwAgainTextField.setWrongCase(message: Self.messageNotSamePassword)
-            return false
-        }
-        
-        pwAgainTextField.setCorrectCase(message: Self.messageSamePassword)
-        return true
-    }
-    
     private func isSameText(lhs: String?, rhs: String?) -> Bool {
         guard let lhs = lhs, let rhs = rhs else { return false }
         return lhs == rhs
+    }
+}
+
+extension RePasswordValidator {
+    private static let messagePrePasswordFirst = "이전 비밀번호를 먼저 올바르게 입력해주시기 바랍니다."
+    private static let messageNotSamePassword = "비밀번호가 일치하지 않습니다."
+    private static let messageSamePassword = "비밀번호가 일치합니다."
+    
+    override func textFieldDidChangeSelection(_ textField: UITextField) {
+        guard let pwAgainTextField = textField as? RePasswordField else { return }
+        
+        if !pwAgainTextField.pwTextField.isCorrect{
+            pwAgainTextField.setWrongCase(message: Self.messagePrePasswordFirst)
+        } else if !isSameText(lhs: pwAgainTextField.pwTextField.text, rhs: pwAgainTextField.text) {
+            pwAgainTextField.setWrongCase(message: Self.messageNotSamePassword)
+        } else {
+            pwAgainTextField.setCorrectCase(message: Self.messageSamePassword)
+        }
+    
+        super.textFieldDidChangeSelection(textField)
+    }
+    
+    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+        guard let pwAgainTextField = textField as? RePasswordField else { return false }
+        
+        if !pwAgainTextField.pwTextField.isCorrect{
+            pwAgainTextField.setWrongCase(message: Self.messagePrePasswordFirst)
+        } else if !isSameText(lhs: pwAgainTextField.pwTextField.text, rhs: pwAgainTextField.text) {
+            pwAgainTextField.setWrongCase(message: Self.messageNotSamePassword)
+        } else {
+            pwAgainTextField.setCorrectCase(message: Self.messageSamePassword)
+        }
+        
+        return super.textFieldShouldEndEditing(textField)
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
@@ -21,15 +21,22 @@ final class RePasswordValidator: SignupValidator {
     private static let messagePrePasswordFirst = "이전 비밀번호를 먼저 올바르게 입력해주시기 바랍니다."
     private static let messageNotSamePassword = "비밀번호가 일치하지 않습니다."
     private static let messageSamePassword = "비밀번호가 일치합니다."
-    override func validateCurrentText(of textField: UITextField) {
-        guard let pwAgainTextField = textField as? RePasswordField else { return }
-        guard pwAgainTextField.pwTextField.isCorrect
-            else { pwAgainTextField.setWrongCase(message: Self.messagePrePasswordFirst); return }
-        guard isSameText(lhs: pwAgainTextField.pwTextField.text, rhs: pwAgainTextField.text)
-            else { pwAgainTextField.setWrongCase(message: Self.messageNotSamePassword); return }
+    @discardableResult
+    override func validateCurrentText(of textField: UITextField) -> Bool {
+        guard super.validateCurrentText(of: textField) else { return false }
+        
+        guard let pwAgainTextField = textField as? RePasswordField else { return false }
+        guard pwAgainTextField.pwTextField.isCorrect else {
+            pwAgainTextField.setWrongCase(message: Self.messagePrePasswordFirst)
+            return false
+        }
+        
+        guard isSameText(lhs: pwAgainTextField.pwTextField.text, rhs: pwAgainTextField.text) else { pwAgainTextField.setWrongCase(message: Self.messageNotSamePassword)
+            return false
+        }
         
         pwAgainTextField.setCorrectCase(message: Self.messageSamePassword)
-        super.validateCurrentText(of: textField)
+        return true
     }
     
     private func isSameText(lhs: String?, rhs: String?) -> Bool {

--- a/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
@@ -9,15 +9,6 @@
 import UIKit
 
 final class RePasswordValidator: SignupValidator {
-    override func textFieldDidChangeSelection(_ textField: UITextField) {
-        validateCurrentText(of: textField)
-    }
-    
-    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        validateCurrentText(of: textField)
-        return true
-    }
-    
     private static let messagePrePasswordFirst = "이전 비밀번호를 먼저 올바르게 입력해주시기 바랍니다."
     private static let messageNotSamePassword = "비밀번호가 일치하지 않습니다."
     private static let messageSamePassword = "비밀번호가 일치합니다."

--- a/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
@@ -20,9 +20,12 @@ final class RePasswordValidator: SignupValidator {
     
     override func validateText(of signupTextableView: SignupTextableView?) {
         guard let signupTextableView = signupTextableView else { return }
-        guard let rePasswordableView = signupTextableView as? RePasswordableView else { return }
-        
-        if !isSameText(lhs: rePasswordableView.passwordTextableView?.text, rhs: rePasswordableView.text) {
+        guard let rePasswordableView = signupTextableView as? RePasswordableView,
+            let passwordTextableView = rePasswordableView.passwordTextableView else { return }
+ 
+        if !passwordTextableView.isCorrect {
+                 rePasswordableView.setWrongCase(message: Self.messagePrePasswordFirst)
+        } else if !isSameText(lhs: passwordTextableView.text, rhs: rePasswordableView.text) {
             rePasswordableView.setWrongCase(message: Self.messageNotSamePassword)
         } else {
             rePasswordableView.setCorrectCase(message: Self.messageSamePassword)
@@ -31,7 +34,3 @@ final class RePasswordValidator: SignupValidator {
         super.validateText(of: rePasswordableView)
     }
 }
-
-//if !pwAgainTextField.passwordTextableView.isCorrect{
-//         pwAgainTextField.setWrongCase(message: Self.messagePrePasswordFirst)
-//}

--- a/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/RePasswordValidator.swift
@@ -13,29 +13,15 @@ final class RePasswordValidator: SignupValidator {
         guard let lhs = lhs, let rhs = rhs else { return false }
         return lhs == rhs
     }
-}
-
-extension RePasswordValidator {
+    
     private static let messagePrePasswordFirst = "이전 비밀번호를 먼저 올바르게 입력해주시기 바랍니다."
     private static let messageNotSamePassword = "비밀번호가 일치하지 않습니다."
     private static let messageSamePassword = "비밀번호가 일치합니다."
-    
-    override func textFieldDidChangeSelection(_ textField: UITextField) {
-        guard let pwAgainTextField = textField as? RePasswordField else { return }
+
+    override func validateText(of signupTextableView: SignupTextableView?) {
+        guard let signupTextableView = signupTextableView else { return }
         
-        if !pwAgainTextField.pwTextField.isCorrect{
-            pwAgainTextField.setWrongCase(message: Self.messagePrePasswordFirst)
-        } else if !isSameText(lhs: pwAgainTextField.pwTextField.text, rhs: pwAgainTextField.text) {
-            pwAgainTextField.setWrongCase(message: Self.messageNotSamePassword)
-        } else {
-            pwAgainTextField.setCorrectCase(message: Self.messageSamePassword)
-        }
-    
-        super.textFieldDidChangeSelection(textField)
-    }
-    
-    override func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        guard let pwAgainTextField = textField as? RePasswordField else { return false }
+        guard let pwAgainTextField = signupTextableView as? RePasswordField else { return }
         
         if !pwAgainTextField.pwTextField.isCorrect{
             pwAgainTextField.setWrongCase(message: Self.messagePrePasswordFirst)
@@ -45,6 +31,6 @@ extension RePasswordValidator {
             pwAgainTextField.setCorrectCase(message: Self.messageSamePassword)
         }
         
-        return super.textFieldShouldEndEditing(textField)
+        super.validateText(of: pwAgainTextField)
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
@@ -13,17 +13,6 @@ class SignupValidator: NSObject {
         return 20
     }
     
-    static let messageRequireText = "필수 항목입니다."
-    @discardableResult
-    func validateCurrentText(of textField: UITextField) -> Bool {
-        guard let signupTextField = textField as? SignupField else { return false }
-        guard !isTextLengthZero(count: signupTextField.text?.count) else {
-            signupTextField.setWrongCase(message: Self.messageRequireText)
-            return false
-        }
-        return true
-    }
-    
     private func isTextLengthZero(count: Int?) -> Bool {
         guard let count = count else { return false }
         return count == 0
@@ -43,13 +32,22 @@ extension SignupValidator: UITextFieldDelegate {
         }
         return true
     }
-    
+
+    static let messageRequireText = "필수 항목입니다."
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        validateCurrentText(of: textField)
+        guard let signupTextField = textField as? SignupField else { return }
+        
+        if isTextLengthZero(count: signupTextField.text?.count) {
+            signupTextField.setWrongCase(message: Self.messageRequireText)
+        }
     }
     
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        validateCurrentText(of: textField)
+        guard let signupTextField = textField as? SignupField else { return false }
+        
+        if isTextLengthZero(count: signupTextField.text?.count) {
+            signupTextField.setWrongCase(message: Self.messageRequireText)
+        }
         return true
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
@@ -13,11 +13,6 @@ class SignupValidator: NSObject {
         return 20
     }
     
-    private func isTextLengthZero(count: Int?) -> Bool {
-        guard let count = count else { return false }
-        return count == 0
-    }
-    
     private static let messageRequireText = "필수 항목입니다."
     
     func validateText(of signupTextableView: SignupTextableView?) {
@@ -26,6 +21,11 @@ class SignupValidator: NSObject {
         if isTextLengthZero(count: signupTextableView.text?.count) {
             signupTextableView.setWrongCase(message: Self.messageRequireText)
         }
+    }
+    
+    private func isTextLengthZero(count: Int?) -> Bool {
+        guard let count = count else { return false }
+        return count == 0
     }
 }
 

--- a/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
@@ -36,11 +36,14 @@ class SignupValidator: NSObject, UITextFieldDelegate {
     }
     
     static let messageRequireText = "필수 항목입니다."
-    func validateCurrentText(of textField: UITextField) {
-        guard let signupTextField = textField as? SignupField else { return }
-        guard isTextLengthZero(count: signupTextField.text?.count) else { return }
-        
-        signupTextField.setWrongCase(message: Self.messageRequireText)
+    @discardableResult
+    func validateCurrentText(of textField: UITextField) -> Bool {
+        guard let signupTextField = textField as? SignupField else { return false }
+        guard !isTextLengthZero(count: signupTextField.text?.count) else {
+            signupTextField.setWrongCase(message: Self.messageRequireText)
+            return false
+        }
+        return true
     }
     
     private func isTextLengthZero(count: Int?) -> Bool {

--- a/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
@@ -30,7 +30,11 @@ class SignupValidator: NSObject {
 }
 
 extension SignupValidator: UITextFieldDelegate {
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
         let textFieldTextCount = textField.text?.count ?? 0
         let totalLength = textFieldTextCount + string.count - range.length
         return totalLength <= textLimit

--- a/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
@@ -8,11 +8,29 @@
 
 import UIKit
 
-class SignupValidator: NSObject, UITextFieldDelegate {
+class SignupValidator: NSObject {
     var textLimit : Int {
         return 20
     }
     
+    static let messageRequireText = "필수 항목입니다."
+    @discardableResult
+    func validateCurrentText(of textField: UITextField) -> Bool {
+        guard let signupTextField = textField as? SignupField else { return false }
+        guard !isTextLengthZero(count: signupTextField.text?.count) else {
+            signupTextField.setWrongCase(message: Self.messageRequireText)
+            return false
+        }
+        return true
+    }
+    
+    private func isTextLengthZero(count: Int?) -> Bool {
+        guard let count = count else { return false }
+        return count == 0
+    }
+}
+
+extension SignupValidator: UITextFieldDelegate {
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let textFieldTextCount = textField.text?.count ?? 0
         let totalLength = textFieldTextCount + string.count - range.length
@@ -33,21 +51,5 @@ class SignupValidator: NSObject, UITextFieldDelegate {
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
         validateCurrentText(of: textField)
         return true
-    }
-    
-    static let messageRequireText = "필수 항목입니다."
-    @discardableResult
-    func validateCurrentText(of textField: UITextField) -> Bool {
-        guard let signupTextField = textField as? SignupField else { return false }
-        guard !isTextLengthZero(count: signupTextField.text?.count) else {
-            signupTextField.setWrongCase(message: Self.messageRequireText)
-            return false
-        }
-        return true
-    }
-    
-    private func isTextLengthZero(count: Int?) -> Bool {
-        guard let count = count else { return false }
-        return count == 0
     }
 }

--- a/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
@@ -38,7 +38,7 @@ extension SignupValidator: UITextFieldDelegate {
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if let signupTextField = textField as? SignupField {
+        if let signupTextField = textField as? FormField {
             signupTextField.nextResonder?.becomeFirstResponder()
         }
         return true

--- a/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
+++ b/iOS/SignupApp/SignupApp/Delegates/SignupValidator.swift
@@ -17,6 +17,16 @@ class SignupValidator: NSObject {
         guard let count = count else { return false }
         return count == 0
     }
+    
+    private static let messageRequireText = "필수 항목입니다."
+    
+    func validateText(of signupTextableView: SignupTextableView?) {
+        guard let signupTextableView = signupTextableView else { return }
+        
+        if isTextLengthZero(count: signupTextableView.text?.count) {
+            signupTextableView.setWrongCase(message: Self.messageRequireText)
+        }
+    }
 }
 
 extension SignupValidator: UITextFieldDelegate {
@@ -32,22 +42,13 @@ extension SignupValidator: UITextFieldDelegate {
         }
         return true
     }
-
-    static let messageRequireText = "필수 항목입니다."
+    
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        guard let signupTextField = textField as? SignupField else { return }
-        
-        if isTextLengthZero(count: signupTextField.text?.count) {
-            signupTextField.setWrongCase(message: Self.messageRequireText)
-        }
+        validateText(of: textField as? SignupField)
     }
     
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        guard let signupTextField = textField as? SignupField else { return false }
-        
-        if isTextLengthZero(count: signupTextField.text?.count) {
-            signupTextField.setWrongCase(message: Self.messageRequireText)
-        }
+        validateText(of: textField as? SignupField)
         return true
     }
 }

--- a/iOS/SignupApp/SignupApp/LoginViewController.swift
+++ b/iOS/SignupApp/SignupApp/LoginViewController.swift
@@ -33,7 +33,7 @@ final class LoginViewController: UIViewController {
                                  from: SignupURL.urlStringLoginInfo,
                                  data: jsonData) { data in
                                     guard let data = data else { return }
-                                    guard let loginResponse = DataCoder.decodeJSONData(type: Response.self,
+                                    guard let loginResponse = DataCoder.decodeJSONData(type: LoginResponse.self,
                                                                                        data: data,
                                                                                        dateDecodingStrategy: nil) else { return }
                                     resultHandler(loginResponse.success)

--- a/iOS/SignupApp/SignupApp/LoginViewController.swift
+++ b/iOS/SignupApp/SignupApp/LoginViewController.swift
@@ -29,15 +29,21 @@ final class LoginViewController: UIViewController {
         let login = Login(userId: idTextField.text!,
                           password: pwTextField.text!)
         guard let jsonData = DataCoder.encodeJSONData(login) else { return }
-        NetworkManager.excuteURLSession(method: .post,
-                                 from: SignupURL.urlStringLoginInfo,
-                                 data: jsonData) { data in
-                                    guard let data = data else { return }
-                                    guard let loginResponse = DataCoder.decodeJSONData(type: LoginResponse.self,
-                                                                                       data: data,
-                                                                                       dateDecodingStrategy: nil) else { return }
-                                    resultHandler(loginResponse.success)
-                                    
+        
+        NetworkManager.excuteURLSession(
+            method: .post,
+            from: SignupURL.urlStringLoginInfo,
+            data: jsonData
+        ) { data in
+            guard let data = data else { return }
+            guard let loginResponse = DataCoder.decodeJSONData(
+                type: LoginResponse.self,
+                data: data,
+                dateDecodingStrategy: nil
+                ) else { return }
+            
+            resultHandler(loginResponse.success)
+            
         }
     }
     

--- a/iOS/SignupApp/SignupApp/Models/CreateUserResponse.swift
+++ b/iOS/SignupApp/SignupApp/Models/CreateUserResponse.swift
@@ -1,13 +1,13 @@
 //
-//  IDResponse.swift
+//  CreateUserResponse.swift
 //  SignupApp
 //
-//  Created by kimdo2297 on 2020/03/27.
+//  Created by kimdo2297 on 2020/06/12.
 //  Copyright © 2020 Jason. All rights reserved.
 //
 
 import Foundation
 
-struct Response: Codable {
+struct CreateUserResponse: Codable {
     let success: Bool
 }

--- a/iOS/SignupApp/SignupApp/Models/IDResponse.swift
+++ b/iOS/SignupApp/SignupApp/Models/IDResponse.swift
@@ -1,0 +1,17 @@
+//
+//  IDResponse.swift
+//  SignupApp
+//
+//  Created by kimdo2297 on 2020/06/12.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+struct IDResponse: Codable {
+    let isOverlapped: Bool
+    
+    private enum CodingKeys: String, CodingKey {
+        case isOverlapped = "success"
+    }
+}

--- a/iOS/SignupApp/SignupApp/Models/LoginResponse.swift
+++ b/iOS/SignupApp/SignupApp/Models/LoginResponse.swift
@@ -1,0 +1,13 @@
+//
+//  IDResponse.swift
+//  SignupApp
+//
+//  Created by kimdo2297 on 2020/03/27.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+struct LoginResponse: Codable {
+    let success: Bool
+}

--- a/iOS/SignupApp/SignupApp/SignupViewController.swift
+++ b/iOS/SignupApp/SignupApp/SignupViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 final class SignupViewController: UIViewController {
-    @IBOutlet weak var idTextField: SignupField!
+    @IBOutlet weak var idTextField: IDField!
     @IBOutlet weak var pwTextField: SignupField!
     @IBOutlet weak var pwAgainTextField: RePasswordField!
     @IBOutlet weak var nameTextField: SignupField!
@@ -56,6 +56,23 @@ final class SignupViewController: UIViewController {
         pwTextField.nextResonder = pwAgainTextField
         pwAgainTextField.nextResonder = nameTextField
         nameTextField.nextResonder = completeButton
+    }
+    
+    @IBAction func validatationButtonDidTouch(_ sender: OverlapValidationButton) {
+        guard idTextField.status == .isCorrectButNotCheckOverlapValidation else { return }
+        
+        sender.validateOverlappedID(idTextField.text) { isOverlapped in
+            if isOverlapped {
+                DispatchQueue.main.async {
+                    self.idTextField.setWrongCase(message: IDValidator.messageOverlappedID)
+                }
+                return
+            }
+            DispatchQueue.main.async {
+                self.idTextField.setCorrectCase(message: IDValidator.messageCorrectID)
+                self.idTextField.status = .isCorrect
+            }
+        }
     }
 }
 

--- a/iOS/SignupApp/SignupApp/SignupViewController.swift
+++ b/iOS/SignupApp/SignupApp/SignupViewController.swift
@@ -51,7 +51,7 @@ final class SignupViewController: UIViewController {
         pwAgainTextField.signupFieldDelegate = self
         nameTextField.signupFieldDelegate = self
     }
-
+    
     private func setNextButtonDelegate() {
         completeButton.delegate = self
     }
@@ -119,15 +119,19 @@ extension SignupViewController: CompleteButtonDelegate {
                         password: pwTextField.text!,
                         name: nameTextField.text!)
         guard let jsonData = DataCoder.encodeJSONData(user) else { return }
-        NetworkManager.excuteURLSession(method: .post,
-                                        from: SignupURL.urlStringUserIntitatationInfo,
-                                        data: jsonData) { data in
-                                            guard let data = data else { return }
-                                            guard let createUserResponse = DataCoder.decodeJSONData(type: CreateUserResponse.self,
-                                                                                              data: data,
-                                                                                              dateDecodingStrategy: nil)
-                                                else { return }
-                                            resultHandler(createUserResponse.success)
+        
+        NetworkManager.excuteURLSession(
+            method: .post,
+            from: SignupURL.urlStringUserIntitatationInfo,
+            data: jsonData
+        ) { data in
+            guard let data = data else { return }
+            guard let createUserResponse = DataCoder.decodeJSONData(
+                type: CreateUserResponse.self,
+                data: data,
+                dateDecodingStrategy: nil) else { return }
+            
+            resultHandler(createUserResponse.success)
         }
     }
     

--- a/iOS/SignupApp/SignupApp/SignupViewController.swift
+++ b/iOS/SignupApp/SignupApp/SignupViewController.swift
@@ -23,8 +23,13 @@ final class SignupViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setRePasswordField()
         setDelegates()
         setNextResponders()
+    }
+    
+    private func setRePasswordField() {
+        pwAgainTextField.passwordTextableView = pwTextField
     }
     
     private func setDelegates() {

--- a/iOS/SignupApp/SignupApp/SignupViewController.swift
+++ b/iOS/SignupApp/SignupApp/SignupViewController.swift
@@ -118,11 +118,11 @@ extension SignupViewController: CompleteButtonDelegate {
                                         from: SignupURL.urlStringUserIntitatationInfo,
                                         data: jsonData) { data in
                                             guard let data = data else { return }
-                                            guard let userResponse = DataCoder.decodeJSONData(type: Response.self,
+                                            guard let createUserResponse = DataCoder.decodeJSONData(type: CreateUserResponse.self,
                                                                                               data: data,
                                                                                               dateDecodingStrategy: nil)
                                                 else { return }
-                                            resultHandler(userResponse.success)
+                                            resultHandler(createUserResponse.success)
         }
     }
     

--- a/iOS/SignupApp/SignupApp/SignupViewController.swift
+++ b/iOS/SignupApp/SignupApp/SignupViewController.swift
@@ -64,12 +64,12 @@ final class SignupViewController: UIViewController {
         sender.validateOverlappedID(idTextField.text) { isOverlapped in
             if isOverlapped {
                 DispatchQueue.main.async {
-                    self.idTextField.setWrongCase(message: IDValidator.messageOverlappedID)
+                    self.idTextField.setWrongCaseOverlappedID()
                 }
                 return
             }
             DispatchQueue.main.async {
-                self.idTextField.setCorrectCase(message: IDValidator.messageCorrectID)
+                self.idTextField.setCorrectCase()
                 self.idTextField.status = .isCorrect
             }
         }

--- a/iOS/SignupApp/SignupApp/Utils/DataCoder.swift
+++ b/iOS/SignupApp/SignupApp/Utils/DataCoder.swift
@@ -9,9 +9,11 @@
 import Foundation
 
 final class DataCoder {
-    static func decodeJSONData<T>(type: T.Type,
-                                  data: Data,
-                                  dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?) -> T? where T: Decodable {
+    static func decodeJSONData<T>(
+        type: T.Type,
+        data: Data,
+        dateDecodingStrategy: JSONDecoder.DateDecodingStrategy?
+    ) -> T? where T: Decodable {
         let jsonDecoder: JSONDecoder = {
             let jsonDecoder = JSONDecoder()
             if let dateDecodingStrategy = dateDecodingStrategy {

--- a/iOS/SignupApp/SignupApp/Views/IDTextableView.swift
+++ b/iOS/SignupApp/SignupApp/Views/IDTextableView.swift
@@ -1,0 +1,19 @@
+//
+//  IDTextableView.swift
+//  SignupApp
+//
+//  Created by kimdo2297 on 2020/06/15.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+enum Status {
+    case isNotCorrect
+    case isCorrectButNotCheckOverlapValidation
+    case isCorrect
+}
+
+protocol IDTextableView: SignupTextableView {
+    var status: Status {get set}
+}

--- a/iOS/SignupApp/SignupApp/Views/IDableView.swift
+++ b/iOS/SignupApp/SignupApp/Views/IDableView.swift
@@ -14,6 +14,6 @@ enum Status {
     case isCorrect
 }
 
-protocol IDTextableView: SignupTextableView {
+protocol IDableView: SignupTextableView {
     var status: Status {get set}
 }

--- a/iOS/SignupApp/SignupApp/Views/OverlapValidationButton.swift
+++ b/iOS/SignupApp/SignupApp/Views/OverlapValidationButton.swift
@@ -25,11 +25,11 @@ final class OverlapValidationButton: UIButton {
             from: "\(SignupURL.urlStringUserIDInfo)\(id)", data: nil) { data in
                 guard let data = data else { return }
                 guard let idResponse = DataCoder.decodeJSONData(
-                    type: Response.self,
+                    type: IDResponse.self,
                     data: data,
                     dateDecodingStrategy: nil
                     ) else { return }
-                completion(idResponse.success)
+                completion(idResponse.isOverlapped)
         }
     }
 }

--- a/iOS/SignupApp/SignupApp/Views/OverlapValidationButton.swift
+++ b/iOS/SignupApp/SignupApp/Views/OverlapValidationButton.swift
@@ -1,0 +1,35 @@
+//
+//  OverlapValidationButton.swift
+//  SignupApp
+//
+//  Created by kimdo2297 on 2020/06/12.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class OverlapValidationButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    func validateOverlappedID(_ id: String?, completion: @escaping (Bool) -> ()) {
+        guard let id = id else { return }
+        
+        NetworkManager.excuteURLSession(
+            method: .get,
+            from: "\(SignupURL.urlStringUserIDInfo)\(id)", data: nil) { data in
+                guard let data = data else { return }
+                guard let idResponse = DataCoder.decodeJSONData(
+                    type: Response.self,
+                    data: data,
+                    dateDecodingStrategy: nil
+                    ) else { return }
+                completion(idResponse.success)
+        }
+    }
+}

--- a/iOS/SignupApp/SignupApp/Views/RePasswordableView.swift
+++ b/iOS/SignupApp/SignupApp/Views/RePasswordableView.swift
@@ -1,0 +1,13 @@
+//
+//  RePasswordView.swift
+//  SignupApp
+//
+//  Created by kimdo2297 on 2020/06/15.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+protocol RePasswordableView: SignupTextableView {
+    var passwordTextableView: SignupTextableView? {get set}
+}

--- a/iOS/SignupApp/SignupApp/Views/SignupTextableView.swift
+++ b/iOS/SignupApp/SignupApp/Views/SignupTextableView.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 protocol SignupTextableView where Self: UIView {
+    var isCorrect: Bool {get set}
     var text: String? {get set}
     
     func setWrongCase(message: String)

--- a/iOS/SignupApp/SignupApp/Views/SignupTextableView.swift
+++ b/iOS/SignupApp/SignupApp/Views/SignupTextableView.swift
@@ -1,0 +1,16 @@
+//
+//  SignupTextableView.swift
+//  SignupApp
+//
+//  Created by kimdo2297 on 2020/06/15.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+protocol SignupTextableView where Self: UIView {
+    var text: String? {get set}
+    
+    func setWrongCase(message: String)
+    func setCorrectCase(message: String)
+}

--- a/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/IDField.swift
+++ b/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/IDField.swift
@@ -23,4 +23,12 @@ final class IDField: SignupField {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
+    
+    func setWrongCaseOverlappedID() {
+        super.setWrongCase(message: "이미 사용중인 아이디입니다.")
+    }
+
+    override func setCorrectCase(message: String = "사용 가능한 아이디입니다.") {
+        super.setCorrectCase(message: message)
+    }
 }

--- a/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/IDField.swift
+++ b/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/IDField.swift
@@ -8,12 +8,7 @@
 
 import UIKit
 
-final class IDField: SignupField {
-    enum Status {
-        case isNotCorrect
-        case isCorrectButNotCheckOverlapValidation
-        case isCorrect
-    }
+final class IDField: SignupField, IDTextableView {
     var status = Status.isNotCorrect
 
     override init(frame: CGRect) {

--- a/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/IDField.swift
+++ b/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/IDField.swift
@@ -1,0 +1,26 @@
+//
+//  IDField.swift
+//  SignupApp
+//
+//  Created by kimdo2297 on 2020/06/12.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import UIKit
+
+final class IDField: SignupField {
+    enum Status {
+        case isNotCorrect
+        case isCorrectButNotCheckOverlapValidation
+        case isCorrect
+    }
+    var status = Status.isNotCorrect
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}

--- a/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/IDField.swift
+++ b/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/IDField.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class IDField: SignupField, IDTextableView {
+final class IDField: SignupField, IDableView {
     var status = Status.isNotCorrect
 
     override init(frame: CGRect) {

--- a/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/RePasswordField.swift
+++ b/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/RePasswordField.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-final class RePasswordField: SignupField {
-    @IBOutlet weak var pwTextField: SignupField!
+final class RePasswordField: SignupField, RePasswordableView {
+    var passwordTextableView: SignupTextableView?
 }
-

--- a/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/SignupField.swift
+++ b/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/SignupField.swift
@@ -13,7 +13,7 @@ protocol SignupFieldDelegate: class {
 }
 
 class SignupField: FormField, SignupTextableView {
-    private(set) var isCorrect = false {
+    var isCorrect = false {
         didSet {
             guard isCorrect != oldValue else { return }
             signupFieldDelegate?.signupFieldIsCorrectDidChange()

--- a/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/SignupField.swift
+++ b/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/SignupField.swift
@@ -13,7 +13,6 @@ protocol SignupFieldDelegate: class {
 }
 
 class SignupField: FormField {
-    static let notificationIsCorrectDidChange = Notification.Name("isCorrectDidChange")
     private(set) var isCorrect = false {
         didSet {
             guard isCorrect != oldValue else { return }

--- a/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/SignupField.swift
+++ b/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/SignupField.swift
@@ -34,7 +34,9 @@ class SignupField: FormField, SignupTextableView {
     
     private func setMessageLabel() {
         addSubview(messageLabel)
-        messageLabel.trailingAnchor.constraint(greaterThanOrEqualTo: safeAreaLayoutGuide.trailingAnchor).isActive = true
+        messageLabel.trailingAnchor.constraint(
+            greaterThanOrEqualTo: safeAreaLayoutGuide.trailingAnchor
+        ).isActive = true
         messageLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
         messageLabel.topAnchor.constraint(equalTo: self.bottomAnchor, constant: 2).isActive = true
     }

--- a/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/SignupField.swift
+++ b/iOS/SignupApp/SignupApp/Views/TextFields/SignupTextFields/SignupField.swift
@@ -12,7 +12,7 @@ protocol SignupFieldDelegate: class {
     func signupFieldIsCorrectDidChange()
 }
 
-class SignupField: FormField {
+class SignupField: FormField, SignupTextableView {
     private(set) var isCorrect = false {
         didSet {
             guard isCorrect != oldValue else { return }


### PR DESCRIPTION
> Issue #56 을 구현하였습니다.

### 1. "필수 항목입니다." 가 보이지 않는 버그를 수정하였습니다.

이전 코드는 "필수 항목입니다."라는 메시지가 다른 유효검사에 의해 최종적으로 보이지 않았던 버그가 있었습니다.
이 버그를 `validateCurrentText` 메소드가 호출될 때 부모 메소드가 먼저 호출되고, 부모 메소드의 리턴값이 true이면 다른 유효검사를 진행하고, 리턴값이 false 이면 다른 유효검사를 진행하지 않도록 코드 수정하여 "필수 항목입니다."라는 메시지가 최종적으로 보이도록 버그를 해결하였습니다. 

![require](https://user-images.githubusercontent.com/38216027/84371008-00be0d00-ac14-11ea-9328-3ffad6b76326.gif)

### 2. 중복 확인 버튼 추가하였습니다.

* 이전 코드에서는 아이디 유효검사가 동기적인 검사(아이디의 조건이 올바른지)와 비동기검사(중복된 아이디가 아닌지)를 한 메소드에서 모두 하는 코드였는데 이는 사용자 입장에서 구분이 분명하지 않는 좋지 못한 코드라고 생각했습니다. 띠라서 중복 검사를 사용자가 직접하도록 하기 위해 중복 확인을 하는 버튼을 추가하여 중복 아이디 검사 메소드를 분리하였습니다. 

![idCorrect](https://user-images.githubusercontent.com/38216027/84474542-fa886900-acc5-11ea-8a4c-884bddb95cc5.gif)
